### PR TITLE
Fix diff parsing for translations

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -94,8 +94,8 @@ jobs:
           newlines = []
           del_list = []
           
-          for i,item in enumerate(result):
-            if '+' in item:
+          for i, item in enumerate(result):
+            if item.startswith('+ '):
                 newlines.append(item.strip('\n'))
           
           for j,jtem in enumerate(newlines):
@@ -105,8 +105,8 @@ jobs:
           for a,atem in enumerate(del_list):
             newlines.pop(atem - a)
           
-          for k,ktem in enumerate(newlines):
-            # ktem = ktem.lstrip('+ ').lstrip('# ')
+          for k, ktem in enumerate(newlines):
+            ktem = ktem.lstrip('+ ').lstrip('# ')
             print(ktem)
             newlines[k] = tl.translate(text=ktem, src='zh-cn', dest='en').text
           


### PR DESCRIPTION
## Summary
- fix string prefix check when scanning for new lines in auto-translation workflow
- remove diff markers before translating

## Testing
- `pytest -q` *(fails: command not found)*
